### PR TITLE
Add resubscribe on reconnect capability

### DIFF
--- a/lib/absinthe_websocket/supervisor.ex
+++ b/lib/absinthe_websocket/supervisor.ex
@@ -21,11 +21,22 @@ defmodule AbsintheWebSocket.Supervisor do
     url = Keyword.get(args, :url)
     token = Keyword.get(args, :token)
     subscriber = Keyword.get(args, :subscriber)
+    resubscribe_on_disconnect = Keyword.get(args, :resubscribe_on_disconnect, false)
+    disconnect_sleep = Keyword.get(args, :disconnect_sleep)
 
     children = [
       worker(AbsintheWebSocket.QueryServer, [[socket: socket_name],[name: query_server_name]]),
       worker(AbsintheWebSocket.SubscriptionServer, [[socket: socket_name, subscriber: subscriber], [name: subscription_server_name]]),
-      worker(AbsintheWebSocket.WebSocket, [[subscription_server: subscription_server_name, url: url, token: token], [name: socket_name]]),
+      worker(AbsintheWebSocket.WebSocket, [
+        [
+          subscription_server: subscription_server_name,
+          url: url,
+          token: token,
+          resubscribe_on_disconnect: resubscribe_on_disconnect,
+          disconnect_sleep: disconnect_sleep
+        ],
+        [name: socket_name]
+      ]),
     ]
 
     # restart everything on failures

--- a/lib/absinthe_websocket/websocket.ex
+++ b/lib/absinthe_websocket/websocket.ex
@@ -71,7 +71,7 @@ defmodule AbsintheWebSocket.WebSocket do
 
     state = Map.put(state, :heartbeat_timer, nil)
 
-    :timer.sleep(Map.get(state, :disconnect_sleep, @disconnect_sleep))
+    :timer.sleep(state.disconnect_sleep)
 
     {:reconnect, state}
   end

--- a/lib/absinthe_websocket/websocket.ex
+++ b/lib/absinthe_websocket/websocket.ex
@@ -16,7 +16,22 @@ defmodule AbsintheWebSocket.WebSocket do
       url
     end
     subscription_server = Keyword.get(args, :subscription_server)
-    state = %{subscriptions: %{}, queries: %{}, msg_ref: 0, heartbeat_timer: nil, socket: name, subscription_server: subscription_server}
+    resubscribe_on_disconnect = Keyword.get(args, :resubscribe_on_disconnect, false)
+    disconnect_sleep = case Keyword.get(args, :disconnect_sleep) do
+      nil -> @disconnect_sleep
+      sleep -> sleep
+    end
+    state = %{
+      subscriptions: %{},
+      subscriptions_info: %{},
+      queries: %{},
+      msg_ref: 0,
+      heartbeat_timer: nil,
+      socket: name,
+      subscription_server: subscription_server,
+      resubscribe_on_disconnect: resubscribe_on_disconnect,
+      disconnect_sleep: disconnect_sleep
+    }
     WebSockex.start_link(full_url, __MODULE__, state, handle_initial_conn_failure: true, async: true, name: name)
   end
 
@@ -37,6 +52,9 @@ defmodule AbsintheWebSocket.WebSocket do
 
     WebSockex.cast(socket, {:join})
 
+    # resubscribe on reconnect (i.e. subscriptions already exist in state)
+    if Map.get(state, :resubscribe_on_disconnect), do: handle_resubscribe(socket, state)
+
     # Send a heartbeat
     heartbeat_timer = Process.send_after(self(), :heartbeat, @heartbeat_sleep)
     state = Map.put(state, :heartbeat_timer, heartbeat_timer)
@@ -53,7 +71,7 @@ defmodule AbsintheWebSocket.WebSocket do
 
     state = Map.put(state, :heartbeat_timer, nil)
 
-    :timer.sleep(@disconnect_sleep)
+    :timer.sleep(Map.get(state, :disconnect_sleep, @disconnect_sleep))
 
     {:reconnect, state}
   end
@@ -147,9 +165,15 @@ defmodule AbsintheWebSocket.WebSocket do
 
     queries = Map.put(queries, msg_ref, {:subscribe, pid, subscription_name})
 
+    subscriptions_info =
+      state
+      |> Map.get(:subscriptions_info, %{})
+      |> Map.put(subscription_name, {pid, query, variables})
+
     state = state
     |> Map.put(:queries, queries)
     |> Map.put(:msg_ref, msg_ref + 1)
+    |> Map.put(:subscriptions_info, subscriptions_info)
 
     {:reply, {:text, msg}, state}
   end
@@ -170,9 +194,15 @@ defmodule AbsintheWebSocket.WebSocket do
 
       queries = Map.put(queries, msg_ref, {:unsubscribe, pid, subscription_name})
 
+      subscriptions_info =
+        state
+        |> Map.get(:subscriptions_info, %{})
+        |> Map.drop(subscription_name)
+
       state = state
       |> Map.put(:queries, queries)
       |> Map.put(:msg_ref, msg_ref + 1)
+      |> Map.put(:subscriptions_info, subscriptions_info)
 
       {:reply, {:text, msg}, state}
     else
@@ -263,5 +293,13 @@ defmodule AbsintheWebSocket.WebSocket do
     Logger.info "#{__MODULE__} - Msg: #{inspect msg}"
 
     {:ok, state}
+  end
+
+  def handle_resubscribe(socket, state) do
+    state
+    |> Map.get(:subscriptions_info, %{})
+    |> Enum.each(fn {sub_name, {pid, query, variables}} ->
+      subscribe(socket, pid, sub_name, query, variables)
+    end)
   end
 end

--- a/lib/absinthe_websocket/websocket.ex
+++ b/lib/absinthe_websocket/websocket.ex
@@ -194,7 +194,7 @@ defmodule AbsintheWebSocket.WebSocket do
       subscriptions_info =
         state
         |> Map.get(:subscriptions_info, %{})
-        |> Map.drop(subscription_name)
+        |> Map.delete(subscription_name)
 
       state = state
       |> Map.put(:queries, queries)

--- a/lib/absinthe_websocket/websocket.ex
+++ b/lib/absinthe_websocket/websocket.ex
@@ -17,10 +17,7 @@ defmodule AbsintheWebSocket.WebSocket do
     end
     subscription_server = Keyword.get(args, :subscription_server)
     resubscribe_on_disconnect = Keyword.get(args, :resubscribe_on_disconnect, false)
-    disconnect_sleep = case Keyword.get(args, :disconnect_sleep) do
-      nil -> @disconnect_sleep
-      sleep -> sleep
-    end
+    disconnect_sleep = Keyword.get(args, :disconnect_sleep, @disconnect_sleep)
     state = %{
       subscriptions: %{},
       subscriptions_info: %{},


### PR DESCRIPTION
Our use-case is that we're proxying the subscriptions to another server which, when the other server disconnects for any reason, we need to re-engage the subscriptions. Unfortunately in its current state this project only reconnects the websocket but does not re-issue the subscriptions that it had. This PR is to add that capability. 

Added this new capability as options in the supervisor so the default behavior is as it was before, you'd have to enable `resubscribe_on_disconnect` to enable this new capability. 

Also added the ability to modify the disconnect sleep time via another supervisor parameter `disconnect_sleep` which will default back to the original value of 30s unless explicitly set to a different value. 