### PR TITLE
Add optional async connection

### DIFF
--- a/lib/absinthe_websocket/supervisor.ex
+++ b/lib/absinthe_websocket/supervisor.ex
@@ -21,6 +21,7 @@ defmodule AbsintheWebSocket.Supervisor do
     url = Keyword.get(args, :url)
     token = Keyword.get(args, :token)
     subscriber = Keyword.get(args, :subscriber)
+    async = Keyword.get(args, :async, true)
 
     websocket_worker_args =
       [subscription_server: subscription_server_name, url: url, token: token] ++
@@ -29,7 +30,7 @@ defmodule AbsintheWebSocket.Supervisor do
     children = [
       worker(AbsintheWebSocket.QueryServer, [[socket: socket_name],[name: query_server_name]]),
       worker(AbsintheWebSocket.SubscriptionServer, [[socket: socket_name, subscriber: subscriber], [name: subscription_server_name]]),
-      worker(AbsintheWebSocket.WebSocket, [websocket_worker_args, [name: socket_name]]),
+      worker(AbsintheWebSocket.WebSocket, [websocket_worker_args, [async: async, name: socket_name]]),
     ]
 
     # restart everything on failures

--- a/lib/absinthe_websocket/websocket.ex
+++ b/lib/absinthe_websocket/websocket.ex
@@ -7,6 +7,7 @@ defmodule AbsintheWebSocket.WebSocket do
 
   def start_link(args, opts) do
     name = Keyword.get(opts, :name)
+    async = Keyword.get(opts, :async)
     url = Keyword.get(args, :url)
     token = Keyword.get(args, :token)
     full_url = if token do
@@ -29,7 +30,7 @@ defmodule AbsintheWebSocket.WebSocket do
       resubscribe_on_disconnect: resubscribe_on_disconnect,
       disconnect_sleep: disconnect_sleep
     }
-    WebSockex.start_link(full_url, __MODULE__, state, handle_initial_conn_failure: true, async: true, name: name)
+    WebSockex.start_link(full_url, __MODULE__, state, handle_initial_conn_failure: true, async: async, name: name)
   end
 
   def query(socket, pid, ref, query, variables \\ []) do


### PR DESCRIPTION
This is the companion PR to https://github.com/annkissam/common_graphql_client/pull/10
Ideally I'd probably have made this a config item or even just turned off async entirely, but I wanted to keep it backwards compatible with the existing functionality.