### PR TITLE
Queue messages received while disconnected, process after re-join

### DIFF
--- a/lib/absinthe_websocket/subscription_server.ex
+++ b/lib/absinthe_websocket/subscription_server.ex
@@ -6,6 +6,8 @@ defmodule AbsintheWebSocket.SubscriptionServer do
     socket = Keyword.get(args, :socket)
     subscriber = Keyword.get(args, :subscriber)
     state = %{
+      connected?: false,
+      disconnected_casts: [],
       socket: socket,
       subscriber: subscriber,
       subscriptions: %{},
@@ -25,12 +27,24 @@ defmodule AbsintheWebSocket.SubscriptionServer do
     GenServer.cast(mod, {:unsubscribe, subscription_name})
   end
 
+  def handle_cast({:subscribe, _, _, _, _} = message, %{connected?: false} = state) do
+    state = Map.put(state, :disconnected_casts, state.disconnected_casts ++ [message])
+
+    {:noreply, state}
+  end
+
   def handle_cast({:subscribe, subscription_name, callback, query, variables}, %{socket: socket, subscriptions: subscriptions} = state) do
     AbsintheWebSocket.WebSocket.subscribe(socket, self(), subscription_name, query, variables)
 
     callbacks = Map.get(subscriptions, subscription_name, [])
     subscriptions = Map.put(subscriptions, subscription_name, [callback | callbacks])
     state = Map.put(state, :subscriptions, subscriptions)
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:unsubscribe, _} = message, %{connected?: false} = state) do
+    state = Map.put(state, :disconnected_casts, state.disconnected_casts ++ [message])
 
     {:noreply, state}
   end
@@ -57,6 +71,13 @@ defmodule AbsintheWebSocket.SubscriptionServer do
   def handle_cast({:joined}, %{subscriber: subscriber} = state) do
     apply(subscriber, :subscribe, [])
 
+    Enum.each(state.disconnected_casts, &GenServer.cast(self(), &1))
+    state = Map.merge(state, %{connected?: true, disconnected_casts: []})
+
     {:noreply, state}
+  end
+
+  def handle_cast({:disconnected}, state) do
+    {:noreply, Map.put(state, :connected?, false)}
   end
 end

--- a/lib/absinthe_websocket/websocket.ex
+++ b/lib/absinthe_websocket/websocket.ex
@@ -63,6 +63,8 @@ defmodule AbsintheWebSocket.WebSocket do
   def handle_disconnect(map, %{heartbeat_timer: heartbeat_timer} = state) do
     Logger.error "#{__MODULE__} - Disconnected: #{inspect map}"
 
+    GenServer.cast(state.subscription_server, {:disconnected})
+
     if heartbeat_timer do
       :timer.cancel(heartbeat_timer)
     end


### PR DESCRIPTION
Description of the problem:
 - socket disconnects
 - during disconnected time, messages are received (e.g. subscribes and unsusbscribes)
 - socket reconnects
 - messages received during disconnected time are sent through before the `join`, resulting in `Ignoring unmatched topic "__absinthe__:control"` on the other end for those messages

This is due to messages still being sent to the WebSockex process "mailbox" while disconnected, and the "mailbox" is a FIFO queue, so when the socket reconnects and AbsintheWebSocket sends a new `join`, it gets in line _behind_ the other messages and they get sent over the socket before the join, which means they get ignored on the other end. 

This problem is exacerbated by the fact that when a `subscribe()` is called by a client, it returns `:ok` regardless of whether the socket is connected (i.e. asynchronous cast), so the client is unaware that their subscribe will be ignored after the socket reconnects and will continue operating without an active subscription.  

Our solution in this PR is the following:
 - store `connected?` in the state, default value is `false`, set to `true` after successful join
 - subscribe and unsubscribe messages that happen while `state.connected? == false` go into a `disconnected_casts` array in the state, rather than sending them through `AbsintheWebSocket.WebSocket._`
 - after socket reconnect _and_ successful join, process the messages collected in `state.disconnected_casts` and then clear that collection, set `state.connected?` back to `true`